### PR TITLE
Support asset references from v-img

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,17 @@ module.exports = (api) => {
         .use(VuetifyLoaderPlugin)
     })
   }
+  
+  // Resolve asset references from v-img
+  api.chainWebpack(config => {
+    config.module
+      .rule('vue')
+      .use('vue-loader')
+      .tap(options => ({
+        ...options,
+        transformAssetUrls: {
+          'v-img': 'src',
+        },
+      }))
+  })
 }


### PR DESCRIPTION
`vue-loader` does not automatically `require` assets referenced in the `src` attribute of a [`<v-img>`](https://vuetifyjs.com/en/components/images) tag. This change makes `<v-img>` [work with `vue-loader`](https://vue-loader.vuejs.org/options.html#transformasseturls) in the same way that `<img>` does.

Template markup looking like `<v-img src="@/assets/logo.png">` will now compile properly.
